### PR TITLE
Add sample content plan and pages

### DIFF
--- a/sample-site/README.md
+++ b/sample-site/README.md
@@ -1,0 +1,17 @@
+# Sample Site Content Plan
+
+This folder contains sample HTML pages that can be placed into WordPress as raw HTML blocks using the **Minimal IT Solutions Manager** theme. The site targets two audiences:
+
+1. **Potential Clients** — organizations seeking Andre Hebben's IT expertise or professional collaboration.
+2. **Professional Contacts** — individuals looking up Andre's background and experience.
+
+## Navigation Structure
+
+- `index.html` – Home
+- `about.html` – About Andre
+- `services.html` – IT Services
+- `projects.html` – Featured Projects
+- `resume.html` – Resume Highlights
+- `contact.html` – Contact
+
+Each file includes a basic HTML template suitable for the WordPress block editor.

--- a/sample-site/about.html
+++ b/sample-site/about.html
@@ -1,0 +1,6 @@
+<!-- About Andre Page -->
+<section class="container py-5">
+  <h2 class="mb-4">About Andre</h2>
+  <p>Andre Hebben is an accomplished IT Solutions Manager currently leading the digital infrastructure at <strong>INSIDE Industry Association</strong>. With extensive experience in European Commission CSA projects and enterprise IT management, he specializes in aligning technology with strategic goals.</p>
+  <p>Andre's passion lies in crafting scalable, secure solutions that empower teams and drive innovation.</p>
+</section>

--- a/sample-site/contact.html
+++ b/sample-site/contact.html
@@ -1,0 +1,21 @@
+<!-- Contact Page -->
+<section class="container py-5">
+  <h2 class="mb-4">Contact</h2>
+  <p>Interested in collaborating with Andre or learning more about his services? Please reach out using the form below or connect via LinkedIn.</p>
+  <form>
+    <div class="mb-3">
+      <label for="name" class="form-label">Name</label>
+      <input type="text" id="name" class="form-control" placeholder="Your name" />
+    </div>
+    <div class="mb-3">
+      <label for="email" class="form-label">Email</label>
+      <input type="email" id="email" class="form-control" placeholder="Your email" />
+    </div>
+    <div class="mb-3">
+      <label for="message" class="form-label">Message</label>
+      <textarea id="message" class="form-control" rows="4" placeholder="How can Andre help you?"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Send Message</button>
+  </form>
+  <p class="mt-3">You can also connect with Andre on <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>.</p>
+</section>

--- a/sample-site/index.html
+++ b/sample-site/index.html
@@ -1,0 +1,8 @@
+<!-- Home Page -->
+<section class="container py-5 text-center">
+  <h1 class="display-4">Andre Hebben</h1>
+  <p class="lead">IT Solutions Manager &amp; Technology Leader</p>
+  <p>Delivering streamlined infrastructure and digital transformation for global organizations.</p>
+  <a href="services.html" class="btn btn-primary me-2">Our Services</a>
+  <a href="resume.html" class="btn btn-secondary">Resume</a>
+</section>

--- a/sample-site/projects.html
+++ b/sample-site/projects.html
@@ -1,0 +1,23 @@
+<!-- Projects Page -->
+<section class="container py-5">
+  <h2 class="mb-4">Featured Projects</h2>
+  <p>Andre has contributed to multiple Coordination and Support Action projects funded by the European Commission, focusing on advanced manufacturing and digital innovation.</p>
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">CSA Initiative A</h5>
+          <p class="card-text">Supported stakeholder outreach and IT infrastructure planning.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">CSA Initiative B</h5>
+          <p class="card-text">Led cloud migration to ensure scalability and security.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/sample-site/resume.html
+++ b/sample-site/resume.html
@@ -1,0 +1,11 @@
+<!-- Resume Page -->
+<section class="container py-5">
+  <h2 class="mb-4">Resume Highlights</h2>
+  <p>Andre Hebben brings over a decade of experience in IT leadership roles. Below is a condensed snapshot of his career.</p>
+  <ul>
+    <li><strong>IT Manager, INSIDE Industry Association</strong> — overseeing infrastructure, security, and digital strategy.</li>
+    <li><strong>CSA Project Lead</strong> — managing technology work packages for European Commission initiatives.</li>
+    <li><strong>Independent Consultant</strong> — delivering cloud and systems engineering projects for multinational clients.</li>
+  </ul>
+  <p><a href="/" class="btn btn-primary">Download Full CV</a></p>
+</section>

--- a/sample-site/services.html
+++ b/sample-site/services.html
@@ -1,0 +1,11 @@
+<!-- Services Page -->
+<section class="container py-5">
+  <h2 class="mb-4">IT Services</h2>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Infrastructure Planning &amp; Optimization</li>
+    <li class="list-group-item">Cloud Migration &amp; Management</li>
+    <li class="list-group-item">Security &amp; Compliance Consulting</li>
+    <li class="list-group-item">Project Management &amp; Stakeholder Coordination</li>
+  </ul>
+  <p class="mt-4">Andre collaborates with organizations to transform their IT environments and achieve measurable results.</p>
+</section>


### PR DESCRIPTION
## Summary
- add a new `sample-site` folder with example HTML content
- include navigation overview in `README.md`
- provide sample pages for home, about, services, projects, resume and contact

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fc37c804c8332b68af087ee2a8a20